### PR TITLE
items buyer_idの追加

### DIFF
--- a/app/models/items_status.rb
+++ b/app/models/items_status.rb
@@ -1,5 +1,0 @@
-class ItemsStatus < ApplicationRecord
-  # belongs_to :item
-  belongs_to :user
-
-end

--- a/db/migrate/20200508122724_drop_item_status.rb
+++ b/db/migrate/20200508122724_drop_item_status.rb
@@ -1,0 +1,5 @@
+class DropItemStatus < ActiveRecord::Migration[5.2]
+  def change
+    drop_table :items_statuses
+  end
+end

--- a/db/migrate/20200508122803_add_buyer_id_to_items.rb
+++ b/db/migrate/20200508122803_add_buyer_id_to_items.rb
@@ -1,0 +1,5 @@
+class AddBuyerIdToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :buyer_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_134954) do
+ActiveRecord::Schema.define(version: 2020_05_08_122803) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2020_05_05_134954) do
     t.datetime "updated_at", null: false
     t.bigint "brand_id"
     t.integer "prefecture_id"
+    t.bigint "buyer_id"
     t.index ["brand_id"], name: "fk_rails_36708b3aa6"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["user_id"], name: "index_items_on_user_id"
@@ -100,16 +101,6 @@ ActiveRecord::Schema.define(version: 2020_05_05_134954) do
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_items_comments_on_item_id"
     t.index ["user_id"], name: "index_items_comments_on_user_id"
-  end
-
-  create_table "items_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "item_id", null: false
-    t.string "status", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["item_id"], name: "index_items_statuses_on_item_id"
-    t.index ["user_id"], name: "index_items_statuses_on_user_id"
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# what
1. items_statusテーブルの削除
2. itemsテーブルにbuyer_idの追加
3. items_status modelの削除 

# why
商品出品中/売却済みなどの状態をitemsテーブルで登録できるようにするため

# Implementation test
商品登録時にbuyer_idがnullで入ることを確認
https://gyazo.com/8d35d56aa263f55c9b1de58bef863d5d