### PR TITLE
carrierwaveでの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
-gem 'mini_magick', '~> 4.8'
+# gem 'mini_magick', '~> 4.8'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
@@ -53,6 +53,8 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'better_errors'
+  gem 'binding_of_caller'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
@@ -85,3 +87,6 @@ gem 'active_hash'
 gem 'ancestry'
 gem "aws-sdk-s3", require: false
 gem 'rails-i18n'
+gem 'utf8-cleaner'
+gem 'carrierwave'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,13 @@ GEM
     aws-sigv4 (1.1.3)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.13)
+    better_errors (2.7.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bindex (0.8.1)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -98,6 +104,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    carrierwave (2.0.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     childprocess (3.0.0)
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
@@ -112,6 +125,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    debug_inspector (0.0.3)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -158,6 +172,9 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    image_processing (1.10.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-like (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
@@ -271,6 +288,8 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.2)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
@@ -320,6 +339,8 @@ GEM
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    utf8-cleaner (1.0.0)
+      activesupport
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -340,6 +361,8 @@ DEPENDENCIES
   active_hash
   ancestry
   aws-sdk-s3
+  better_errors
+  binding_of_caller
   bootsnap (>= 1.1.0)
   byebug
   capistrano
@@ -348,6 +371,7 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano3-unicorn
   capybara (>= 2.15)
+  carrierwave
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
@@ -360,7 +384,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
-  mini_magick (~> 4.8)
+  mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
   payjp
   pry-rails
@@ -376,6 +400,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   unicorn (= 5.4.1)
+  utf8-cleaner
   web-console (>= 3.3.0)
 
 RUBY VERSION

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,8 +11,9 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require activestorage
+
 //= require jquery
 //= require jquery_ujs
+
 //= require_tree .
 

--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -1,37 +1,67 @@
-$(function () {
-  var id = 1;
-  $('body').on('change', '#upload_file', function(e){
-    var filesArray = $('.item_images_hidden').val().split(',');
-    var target = e.target;
-    if (filesArray[0] === "") {
-      filesArray.splice(0, 1);
-    }
-    var reader = new FileReader();
-    
-    reader.onload = function(e){
-      $(target).closest('.prepend_area').prepend(`
-      <div class="select_image" data-id=${id-1} data-lightbox="abc">
-        <a href="${e.target.result}" data-lightbox="group">
-          <img src=${e.target.result} id="image_preview" width="300">
-        </a>
-        <p><a href="#">編集</a></p>
-        <p><a class="remove_image">削除</a></p>
-    </div>
-  `);
-      var imagesLength = $('.select_image').length;
-      
-      $(target).closest('.pre-content').css('width', `calc(100% - ${20 * (imagesLength % 5)}%)`);
-    }
-    reader.readAsDataURL(target.files[0]);
-    
-    $(target).closest('.pre-content').append(`<input id="upload_file" class="upload_files", accept="image/png, image/jpeg, image/gif" type="file" name="item[images][]" data-id="${id + 1}">`);
-    $(target).css('width', '0px');
+$(function (){
+  function buildFileField(index) {
+    html = `<input class= "js-file" type= "file"name="item[item_images_attributes][${index}][src]" id="item_item_images_attributes_${index}_src">
+              <div class="js-remove">削除</div>
+            </div>`;  
+    return html;
+  };
+// file_fieldのnameに動的なindexをつける為の配列
+let fileIndex = [1,2,3,4,5,6,7,8,9,10];
 
-    filesArray.push(id);
-    $('.item_images_hidden').val(filesArray);
+  $("body").on('change', '.js-file', function(){
+    $(".prepend_area").append(buildFileField(fileIndex[0]));
+    fileIndex.shift();
+    // 末尾の数に1足した数を追加する
+    fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
+    return false;
+
+  })
+
+
+
+
+})
+
+
+
+
+
+
+// $(function () {
+//   var id = 1;
+//   $('body').on('change', '#upload_file', function(e){
+//     var filesArray = $('.item_images_hidden').val().split(',');
+//     var target = e.target;
+//     if (filesArray[0] === "") {
+//       filesArray.splice(0, 1);
+//     }
+//     var reader = new FileReader();
     
-    var filesArray = $('.item_images_hidden').val().split(',');
-    var imagesLength = $('.select_image').length;
+//     reader.onload = function(e){
+//       $(target).closest('.prepend_area').prepend(`
+//         <div class="select_image" data-id=${id-1} data-lightbox="abc">
+//           <a href="${e.target.result}" data-lightbox="group">
+//             <img src=${e.target.result} id="image_preview" width="300">
+//           </a>
+//             <p><a href="#">編集</a></p>
+//             <p><a class="remove_image">削除</a></p>
+//         </div>
+//       `);
+//       var imagesLength = $('.select_image').length;
+      
+//       $(target).closest('.pre-content').css('width', `calc(100% - ${20 * (imagesLength % 5)}%)`);
+//     }
+//     reader.readAsDataURL(target.files[0]);
+    
+//     $(target).closest('.pre-content').append(`<input id="upload_file" class="upload_files", accept="image/png, image/jpeg, image/gif" type="file" name="item[images][]" data-id="${id + 1}">`);
+//     $(target).css('width', '0px');
+
+//     filesArray.push(id);
+//     $('.item_images_hidden').val(filesArray);
+    
+//     var filesArray = $('.item_images_hidden').val().split(',');
+//     var imagesLength = $('.select_image').length;
+//     var defualtImageText =  $('.pre-content').children('p').html('<p>クリックをしてアップロード</p>');
     // $(document).on('DOMSubtreeModified propertychange', function(){
 
     //   if (imagesLength + 1 === 4) {
@@ -43,79 +73,196 @@ $(function () {
     //   }
     // }
 
+    // )
 
-    switch (imagesLength + 1 ) {
+    // switch (imagesLength + 1 ) {
       
-      case 4: $('.pre-content').children('p').html('<i class="fas fa-camera"></i>');
-      break;
+    //   case 4: $('.pre-content').children('p').html('<i class="fas fa-camera"></i>');
+    //   break;
 
-      case 5: $(target).closest('.pre-content').css('display', 'none');
+    //   case 5: $(target).closest('.pre-content').css('display', 'none');
               // $('.under_area .image_file_area').css('display', 'block');
               // $('.under_area .image_file_area').css('width', '100%');
               // $('.under_area .image_file_area').append(`<input multiple="multiple" id="upload_file" class="upload_files", accept="image/png, image/jpeg, image/gif" type="file" name="item[images][]" data-id="${id + 1}">`);
       //   break;
       // case 10: $(target).closest('.image_file_area').css('display', 'none');     
-        break;
-    }
-    $('body').on('click', '.remove_image', function(){
-      if (imagesLength + 1  < 4){
-        $('.pre-content').children('p').html('<p>クリックをしてアップロード</p>');
-      };
-    })
+  //       break;
+  //   }
+  //   $('body').on('click', '.remove_image', function(){
+  //     if (imagesLength + 1  < 4){
+  //       $('.pre-content').children('p').html('<p>クリックをしてアップロード</p>');
+  //     };
+  //   })
 
 
-  id++;
+  // id++;
   
-  });
+  // });
 
-  $('body').on('click', '.remove_image', function () {
-    // if ($('.select_image').length  < 4){
-    //   $('.pre-content').children('p').html('<p>クリックをしてアップロード</p>');
-    // };
-    var filesArray = $('.item_images_hidden').val().split(',');
-    var id = $(this).closest('.select_image').data('id');
+//   $('body').on('click', '.remove_image', function () {
+//     // if ($('.select_image').length  < 4){
+//     //   $('.pre-content').children('p').html('<p>クリックをしてアップロード</p>');
+//     // };
+//     var filesArray = $('.item_images_hidden').val().split(',');
+//     var id = $(this).closest('.select_image').data('id');
 
-    // 選択されたidとfilesArrayの要素が一致すればfilesArrayから削除
-    $.each(filesArray, function (index, file) {
-      if(id === Number(file)){
-        filesArray.splice(index, 1);
-      };
-      // .item_images_hiddenのval()を更新
-      $('.item_images_hidden').val(filesArray);
-    });
+//     // 選択されたidとfilesArrayの要素が一致すればfilesArrayから削除
+//     $.each(filesArray, function (index, file) {
+//       if(id === Number(file)){
+//         filesArray.splice(index, 1);
+//       };
+//       // .item_images_hiddenのval()を更新
+//       $('.item_images_hidden').val(filesArray);
+//     });
 
 
-    // 選択されたidを持つinput[type="file"]を削除
-    $('.upload_files').each(function (index, element) {
-      if(!$(element).data('id')){
-       return true;
-      }     
-      if($(element).data('id') === Number(id)) {
-        $(element).remove();
-      }
-    });
+//     // 選択されたidを持つinput[type="file"]を削除
+//     $('.upload_files').each(function (index, element) {
+//       if(!$(element).data('id')){
+//        return true;
+//       }     
+//       if($(element).data('id') === Number(id)) {
+//         $(element).remove();
+//       }
+//     });
 
-    // .select_imageを削除
-    $(this).closest('.select_image').remove();
+//     // .select_imageを削除
+//     $(this).closest('.select_image').remove();
 
-    var filesArray = $('.item_images_hidden').val().split(',');
-    var imagesLength = $('.select_image').length;
-    // .image_file_areaの幅を調整
-    if(imagesLength == 5) {
-      // $('.pre-content').css('dispplay', "hidden");
-      if (imagesLength === 4) {
-        var fileField = $('.upload_files');
-        fileField.remove();
-        $('.pre-content:first').append(fileField);
+//     var filesArray = $('.item_images_hidden').val().split(',');
+//     var imagesLength = $('.select_image').length;
+//     // .image_file_areaの幅を調整
+//     if(imagesLength == 5) {
+//       // $('.pre-content').css('dispplay', "hidden");
+//       if (imagesLength === 4) {
+//         var fileField = $('.upload_files');
+//         fileField.remove();
+//         $('.pre-content:first').append(fileField);
 
-      }
-      $('.prec-ontent:last').css('display', 'none');
-      $('.pre-content:first').css('display', 'block').css('width', `calc(100% - ${20 * (imagesLength % 5)}%)`);
-    } else {
-      var width = $('.pre-content:last').css('width');
+//       }
+//       $('.prec-ontent:last').css('display', 'none');
+//       $('.pre-content:first').css('display', 'block').css('width', `calc(100% - ${20 * (imagesLength % 5)}%)`);
+//     } else {
+//       var width = $('.pre-content:last').css('width');
       
-      $('.pre-content:last').css('display', 'block').css('width', `calc(100% - ${20 * (imagesLength % 5)}%)`);
-    }
+//       $('.pre-content:last').css('display', 'block').css('width', `calc(100% - ${20 * (imagesLength % 5)}%)`);
+//     }
     
-  });
-});
+//   });
+// });
+
+
+
+
+
+
+
+
+
+// // $(function(){
+// //   $("form").submit(function(e){
+        
+// //     if ($(".pre-content").html() == ""){
+// //         alert("画像を選択してください");
+      
+// //         return false;
+       
+        
+// //   //   if ($('input[type="hidden"').attr("value") == deleteSrc){
+// //   //   $(this).remove();
+// //   // }
+// //       };
+      
+// //       var inputHidden = []
+// //       inputHidden.push($('input[type="hidden"]'));
+// //       console.log(inputHidden[1])
+// //   })
+
+// //   $(".hidden-field").on('change', function(e){
+// //     var files = e.target.files;
+
+// //     //画像ファイル以外の場合は何もしない
+// //     // if(file.type.indexOf("image") < 0){
+// //     //   return false;
+// //     // }
+// //     // if ($(".pre-content").html() == ""){
+// //     //   alert("画像を選択してください");
+// //     // }
+    
+// //     // var d = (new $.Deferred()).resolve();
+// //     $.each(files,function(i,file){
+      
+// //       //画像ファイル以外の場合は何もしない
+      
+// //       if(file.type.indexOf("image") < 0){
+// //         alert('画像を選択してください');
+// //           return false;
+// //         }
+// //       return previewImage(file);
+// //     });
+// //   })
+// //   var previewImage = function(imageFile){
+   
+// //     var reader = new FileReader();
+// //     // var img = new Image();
+    
+// //     reader.onload = function(e){
+
+// //       //画像のhtml要素を作成
+// //       var preview = `<li class="item-pic">
+                      
+// //                         <img class="item-pic__image" src= ${e.target.result}>
+                      
+// //                       <div class="item-pic__button">
+// //                         <a class="item-pic__button-edit" href="#" style= "color:#333333;" >編集</a>
+// //                         <a class="item-pic__button-delete"style= "color:#333333; cursor: pointer" >削除</a>
+// //                       </div>
+// //                     </li>`;
+      
+      
+// //       // `<li class= "item-pic"><img class="item-pic__image" src = ${e.target.result} ></li>`
+
+// //      //画像をフォームの隣に出力
+// //      $('.pre-content').prepend(preview);
+
+// //     //フォームのリサイズ
+// //       $(".label-content").resize('width', "calc(800px - ($('.item-pic').length * 20%" );
+     
+// //       // 画像が一つ以上ある場合ボックスの文字を写真マークに変更
+// //     if ($(".item-pic").length > 1){
+      
+// //       //画像が一枚出力されたら、文字をカメラマークに変更
+// //       $(".text1").replaceWith("<i class='fas fa-camera'></i>");
+// //     }
+// //     if ($(".item-pic").length > 4){
+// //       //画像が五枚の場合はフォームを非表示
+// //       $(".label-content").hide();
+// //     }
+
+// //     $(document).on('click', '.item-pic__button-delete', function(){
+// //     //  var hiddenInput = $('input[type="hidden"]').attr("type", "file");
+     
+// //        var deleteSrc = ($(this).closest('li').children().attr('src'));
+// //        $(this).closest('li').remove();
+// //       //　file_fieldフォームを削除
+// //       // $('input[type="file"]').remove();
+// //       });
+// //     };
+// //     reader.readAsDataURL(imageFile);
+// //   };
+// // });
+
+//    // cloned = $(".label-content").clone(ture);
+      
+//       //新しいフォームを追加
+//       // $(".post__drop__box__container2").show();
+//     // $('.pre-content2').prepend(preview);
+//     // ($(".item-pic:gt(6)").prepend)
+//     //   $('.pre-content2 ').prepend(preview);
+      
+//     // }
+//     //   console.log($(".item-pic").length);
+//         // var inputHidden = $('input[type="hidden"').length
+//     // console.log(inputHidden)
+//     // if ($('input[type="hidden"').attr("value") == deleteSrc){
+//     //   ;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,7 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
+    @item.item_images.build
     # @item.item_images.build
     @item.build_brand
     # @item.brand.build
@@ -46,7 +47,7 @@ class ItemsController < ApplicationController
 
 
   def create
-  
+    binding.pry
     # Item.create(item_params)
     @item = Item.new(item_params)
     unless @item.valid?
@@ -110,7 +111,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:item_name, :price, :category_id, :status_id, :size, :delivery_method_id, :delivery_fee_id, :prefecture_id, :estimated_delivery_id, brand_attributes: [:name]).merge(user_id: current_user.id).merge(images: images_params) 
+    params.require(:item).permit(:item_name, :price, :category_id, :status_id, :size, :delivery_method_id, :delivery_fee_id, :prefecture_id, :estimated_delivery_id, brand_attributes: [:name], item_images_attributes: [:src, :_destroy, :id]).merge(user_id: current_user.id)
   end
 
   def images_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,8 @@ class Item < ApplicationRecord
   belongs_to :user
   belongs_to :brand
   belongs_to :category
+  has_many :item_images
+  accepts_nested_attributes_for :item_images, allow_destroy: true, update_only: true
   # accepts_nested_attributes_for :item_images
   has_many_attached :images
   accepts_nested_attributes_for :brand

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -1,0 +1,4 @@
+class ItemImage < ApplicationRecord
+  mount_uploader :src, ImageUploader
+  belongs_to :item
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,47 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -10,12 +10,18 @@
           出品画像
           %span.titleContainer__required 必須
         %p.top_text_details 最大10枚までアップロードできます
-        .post__drop__box__container 
+        -# .post__drop__box__container 
+        -#   .prepend_area
+        -#     .pre-content
+        -#       %p クリックをしてアップロード
+        -#       = form.file_field :images, id: "upload_file", class: "upload_files", data:{id: "1"}
+        -#       = form.hidden_field :file, class: "item_images_hidden"            
+
+        .new_item_page_container_main_carrierwave_image
           .prepend_area
-            .pre-content
-              %p クリックをしてアップロード
-              = form.file_field :images, id: "upload_file", class: "upload_files", data:{id: "1"}
-              = form.hidden_field :file, class: "item_images_hidden"            
+            %p.new_item_page_container_main_label
+            = form.fields_for :item_images do |i|
+              = i.file_field :src, class: 'js-file'
       
         -# .post__drop__box__container2           
         -#   .pre-content2  

--- a/db/migrate/20200523081319_create_item_images.rb
+++ b/db/migrate/20200523081319_create_item_images.rb
@@ -1,11 +1,9 @@
 class CreateItemImages < ActiveRecord::Migration[5.2]
   def change
     create_table :item_images do |t|
-      t.string :image, null: false
-      t.integer :item, null: false
+      t.string :src
+      t.references :item, foreign_key: true
       t.timestamps
     end
   end
 end
-
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_122803) do
+ActiveRecord::Schema.define(version: 2020_05_23_081319) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -71,6 +71,14 @@ ActiveRecord::Schema.define(version: 2020_05_08_122803) do
     t.text "evaluation", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "item_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "src"
+    t.bigint "item_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_item_images_on_item_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -138,6 +146,7 @@ ActiveRecord::Schema.define(version: 2020_05_08_122803) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "item_images", "items"
   add_foreign_key "items", "brands"
   add_foreign_key "users", "addresses"
 end

--- a/spec/factories/item_images.rb
+++ b/spec/factories/item_images.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :item_image do
+    
+  end
+end

--- a/spec/models/item_image_spec.rb
+++ b/spec/models/item_image_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ItemImage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# what 
Carrierwaveでの複数画像登録を実装

Item_imagesのテーブルを再度作成
item_controllerのstrong parameterをitem_images_attributes: [:src, :_destroy, :id]に変更
viewとjsを再度書き直し、jsではfileフォームを選択すると追加のfileフォームが出るところまでを実装

現在、複数の画像登録はできます。