### PR TITLE
商品編集時のカテゴリーエラーの解消

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -31,6 +31,8 @@ $(function(){
   }
   $('#item_category_id').on('change', function(){
     var parentCategory = document.getElementById('item_category_id').value;
+    // var parentCategory =$('#item_category_id').data('category');
+    console.log(parentCategory);
     if (parentCategory != "---"){
       $.ajax({
         url: '/items/get_category_children',
@@ -56,6 +58,7 @@ $(function(){
     }
   });
   $('.newcate').on('change', '#child_category', function(){    
+    // var childId = $('#child_category option:selected').data('category');
     var childId = $('#child_category option:selected').data('category');
     console.log(childId);
     if (childId != "---"){

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,10 +10,12 @@ class ItemsController < ApplicationController
     @item.build_brand
   end
   def get_category_children
+    # @category_children = Category.find_by(id: "#{params[:parent_id]}", ancestry: nil).children
     @category_children = Category.find_by(id: "#{params[:parent_id]}", ancestry: nil).children
   end
 
   def get_category_grandchildren
+    # binding.pry
     @category_grandchildren = Category.find("#{params[:child_id]}").children
   end
 
@@ -38,8 +40,27 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
-    # @item.item_images.build
-    # @item.build_brand
+
+
+    grandchild_category = @item.category
+    child_category = grandchild_category.parent
+
+
+    @category_parent_array = []
+    Category.where(ancestry: nil).each do |parent|
+      @category_parent_array << parent.name
+    end
+
+    @category_children_array = []
+    Category.where(ancestry: child_category.ancestry).each do |children|
+      @category_children_array << children
+    end
+
+    @category_grandchildren_array = []
+    Category.where(ancestry: grandchild_category.ancestry).each do |grandchildren|
+      @category_grandchildren_array << grandchildren
+    end
+
   end
   
   def update

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -33,17 +33,6 @@
               .form-file
                 .new_item_page_container_main_label{"data-index" => "#{@item.item_images.count}"}
                   = form.file_field :src, class: 'js-file', id: 'js-file', name: "item[item_images_attributes][#{@item.item_images.count}][src]", data:{ index: "#{@item.item_images.count}"}
-              -# .prepend_area
-              -#   .pre-content
-              -#     = i.label :image, for: "js-file" do
-              -# %p.text 
-              -#   クリックをしてアップロード
-              -# .form-file   
-              -#   .new_item_page_container_main_label{"data-index" => "#{@item.item_images.count}"}
-          
-            -# =form.fields_for :item_images do |i|  
-
-
         .product
           .product__name.titleContainer
             %h1.titleContainer__title 商品名
@@ -56,8 +45,17 @@
             %h1.titleContainer__title カテゴリー
             %h2.titleContainer__required 必須
           .newcate2
-          = form.collection_select :category_id, Category.where(ancestry: nil), :id, :name, prompt: "---", class: ''
+          = form.collection_select(:category_id, Category.where(ancestry: nil), :id, :name, {selected: @item.category.parent.parent.id})
           .newcate
+            .listing-select-wrapper__added#children_wrapper
+              %i.fas.fa-chevron-down.listing-select-wrapper__box--arrow-down
+              .listing-select-wrapper__box
+                = form.select :child_id, options_for_select(@category_children_array.map{|cc| [cc.name, cc.id, {data:{category: cc.id}}]}, {prompt: "指定なし", selected: @item.category.parent.id}),{}, {class: 'listing-select-wrapper__box--select', id: 'child_category'}
+              %i.fas.fa-chevron-down.listing-select-wrapper__box--arrow-down
+            .listing-select-wrapper__added#grandchildren_wrapper
+              .listing-select-wrapper__box
+                = form.select :category_id, options_for_select(@category_grandchildren_array.map{|gc| [gc.name, gc.id, {data:{category: gc.id}}]}, {prompt: "指定なし", selected: @item.category.id}),{}, {class: 'listing-select-wrapper__box--select', id: 'grandchildren_wrapper'}
+      
           .brand.titleContainer
             %h1.titleContainer__title ブランド
             %h2.titleContainer__any 任意


### PR DESCRIPTION
# what
商品編集時、元々持っていたカテゴリーの情報が保てていないエラーが発生していたのでその解消
# why
userにカテゴリーを再度選択させる手間を発生させないため。