### PR TITLE
商品編集カテゴリーエラーの解消

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,13 +4,11 @@ class ItemsController < ApplicationController
     @items = Item.includes(:user, :category).order("created_at DESC")
   end
   
-  def myList
-   
+  def myList   
     @items = Item.where(user_id: current_user.id)
   end
 
   def pay
-  
     Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_SECRET_KEY)
     Payjp::Charge.create(
       :amount => @item.price, #支払金額を引っ張ってくる
@@ -52,52 +50,25 @@ class ItemsController < ApplicationController
     end
   end
 
-  
-
-  def show
-   
+  def show 
   end
   
   def purchase_index
-   
   end
 
   def purchase_edit
-   
   end
-
-
- 
- 
-  def edit
-    @item = Item.find(params[:id])
-
-    grandchild_category = @item.category
-    child_category = grandchild_category.parent
-
-    @category_parent_array = []
-    Category.where(ancestry: nil).each do |parent|
-      @category_parent_array << parent.name
-    end
-
-    @category_children_array = []
-    Category.where(ancestry: child_category.ancestry).each do |children|
-      @category_children_array << children
-    end
-
-    @category_grandchildren_array = []
-    Category.where(ancestry: grandchild_category.ancestry).each do |grandchildren|
-      @category_grandchildren_array << grandchildren
-    end
-  end
-
+  
   def myList
     @items = current_user.items
   end
 
+  def edit
+    set_category
+  end
 
   def update
-    
+    # binding.pry
     if @item.update(item_params)
       redirect_to root_path
     else
@@ -118,6 +89,27 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.includes(:user, :category).find(params[:id])
+  end
+
+  def set_category
+    @item = Item.find(params[:id])
+    grandchild_category = @item.category
+    child_category = grandchild_category.parent
+
+    @category_parent_array = []
+    Category.where(ancestry: nil).each do |parent|
+      @category_parent_array << parent.name
+    end
+
+    @category_children_array = []
+    Category.where(ancestry: child_category.ancestry).each do |children|
+      @category_children_array << children
+    end
+
+    @category_grandchildren_array = []
+    Category.where(ancestry: grandchild_category.ancestry).each do |grandchildren|
+      @category_grandchildren_array << grandchildren
+    end
   end
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,5 +12,6 @@ class Item < ApplicationRecord
   belongs_to_active_hash :estimated_delivery
   belongs_to_active_hash :status
 
+  validates_with MyValidator
   validates :item_name, :price, :status_id, :delivery_method_id, :delivery_fee_id, :prefecture_id, :estimated_delivery_id, :category_id, :item_images, presence: true
 end

--- a/app/validators/my_validator.rb
+++ b/app/validators/my_validator.rb
@@ -1,0 +1,8 @@
+class MyValidator < ActiveModel::Validator
+
+  def validate(record)
+    if record.category_id == 0
+      record.errors.add('category_id', 'は最後まで選択してください')
+    end
+  end
+end

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -45,17 +45,21 @@
             %h1.titleContainer__title カテゴリー
             %h2.titleContainer__required 必須
           .newcate2
-          = form.collection_select(:category_id, Category.where(ancestry: nil), :id, :name, {selected: @item.category.parent.parent.id})
-          .newcate
-            .listing-select-wrapper__added#children_wrapper
-              %i.fas.fa-chevron-down.listing-select-wrapper__box--arrow-down
-              .listing-select-wrapper__box
-                = form.select :child_id, options_for_select(@category_children_array.map{|cc| [cc.name, cc.id, {data:{category: cc.id}}]}, {prompt: "指定なし", selected: @item.category.parent.id}),{}, {class: 'listing-select-wrapper__box--select', id: 'child_category'}
-              %i.fas.fa-chevron-down.listing-select-wrapper__box--arrow-down
-            .listing-select-wrapper__added#grandchildren_wrapper
-              .listing-select-wrapper__box
-                = form.select :category_id, options_for_select(@category_grandchildren_array.map{|gc| [gc.name, gc.id, {data:{category: gc.id}}]}, {prompt: "指定なし", selected: @item.category.id}),{}, {class: 'listing-select-wrapper__box--select', id: 'grandchildren_wrapper'}
-      
+          -if @item.errors.any?
+            = form.collection_select :category_id, Category.where(ancestry: nil), :id, :name, prompt: "---", class: ''
+            .newcate
+          -else 
+            = form.collection_select(:category_id, Category.where(ancestry: nil), :id, :name, {selected: @item.category.parent.parent.id})
+            .newcate
+              .listing-select-wrapper__added#children_wrapper
+                %i.fas.fa-chevron-down.listing-select-wrapper__box--arrow-down
+                .listing-select-wrapper__box
+                  = form.select :child_id, options_for_select(@category_children_array.map{|cc| [cc.name, cc.id, {data:{category: cc.id}}]}, {prompt: "指定なし", selected: @item.category.parent.id}),{}, {class: 'listing-select-wrapper__box--select', id: 'child_category'}
+                %i.fas.fa-chevron-down.listing-select-wrapper__box--arrow-down
+              .listing-select-wrapper__added#grandchildren_wrapper
+                .listing-select-wrapper__box
+                  = form.select :category_id, options_for_select(@category_grandchildren_array.map{|gc| [gc.name, gc.id, {data:{category: gc.id}}]}, {prompt: "指定なし", selected: @item.category.id}),{}, {class: 'listing-select-wrapper__box--select', id: 'grandchildren_wrapper'}
+        
           .brand.titleContainer
             %h1.titleContainer__title ブランド
             %h2.titleContainer__any 任意

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 2020_05_27_143415) do
     t.integer "sales"
     t.integer "point"
     t.text "icon"
-    t.string "birthday"
+    t.date "birthday"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
# what
商品編集親カテゴリー選択時のエラーハンドリングの実装
# why
孫カテゴリーまで選択してもらうよう実装することにより、商品管理がしやすくなるため。